### PR TITLE
Dot files and directories will be ignored

### DIFF
--- a/mocko-proxy/src/definitions/definition.provider.ts
+++ b/mocko-proxy/src/definitions/definition.provider.ts
@@ -17,6 +17,7 @@ const { readFile, readdir, lstat } = promises;
 const MOCKS_DIR = process.env['MOCKS_FOLDER'] || "mocks";
 const MUST_LOAD_DIR = !!process.env['MOCKS_FOLDER'];
 const HCL_EXTENSION = ".hcl";
+const DOT = ".";
 
 export type FileOrDir = {
     name: string,
@@ -106,10 +107,12 @@ export class DefinitionProvider {
 
         const mockFiles = files
             .filter(f => !f.isDir)
+            .filter(f => !f.name.startsWith(DOT))
             .filter(f => f.name.endsWith(HCL_EXTENSION));
 
         const subDirContents = (await Promise.all(files
             .filter(f => f.isDir)
+            .filter(f => !f.name.startsWith(DOT))
             .map(f => this.getMockFilesContent(join(path, f.name)))))
                 .flat();
         

--- a/mocko-proxy/test/mocks/subject/.proxy.hcl
+++ b/mocko-proxy/test/mocks/subject/.proxy.hcl
@@ -1,0 +1,3 @@
+mock "GET /dot-route" {
+    body = "This feature is not working"
+}

--- a/mocko-proxy/test/proxy.js
+++ b/mocko-proxy/test/proxy.js
@@ -25,4 +25,9 @@ module.exports = (mocko, _describe, it) => () => {
         const { status } = await mocko.post('/validate/query?foo=bar');
         expect(status).to.equal(201);
     });
+
+    it('should ignore files and directories starting with dot(.)', async () => {
+        const { status } = await mocko.post('/dot-route');
+        expect(status).to.equal(404);
+    });
 };

--- a/mocko-proxy/test/proxy.js
+++ b/mocko-proxy/test/proxy.js
@@ -27,7 +27,12 @@ module.exports = (mocko, _describe, it) => () => {
     });
 
     it('should ignore files and directories starting with dot(.)', async () => {
-        const { status } = await mocko.post('/dot-route');
-        expect(status).to.equal(404);
+        let code;
+
+        await mocko.get('/dot-route')
+            .then(({ status }) => code = status)
+            .catch(({ response }) => code = response.status);
+
+        expect(code).to.equal(404);
     });
 };


### PR DESCRIPTION
Mock files and directories starting with dot(.) will be ignored.
Test case added to route that is contained in .proxy.hcl file and should ideally return a 404 status.